### PR TITLE
Fix linuxdeploy strip failure on modern glibc systems

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export NO_STRIP=true
+exec npx tauri build "$@"


### PR DESCRIPTION
AppImage build fails on systems with DT_RELR libraries

Problem

On modern distros (e.g. CachyOS, recent Arch), the outdated strip bundled inside linuxdeploy's AppImage doesn't recognize .so files using the DT_RELR relocation format (.relr.dyn section, ELF type 0x13). It errors out on every bundled system library:

ERROR: Strip call failed: ... unknown type [0x13] section `.relr.dyn'
... Unable to recognise the format of the input file
failed to bundle project `failed to run linuxdeploy`

The .deb and .rpm targets build fine — only the AppImage fails at the strip step.

Fix

New build.sh wrapper at the repo root that invokes npx tauri build with NO_STRIP=true. This skips linuxdeploy's strip step — the resulting AppImage is a few MB larger, but runtime behavior is unchanged.

```
./build.sh                       # all bundles
./build.sh --bundles appimage    # AppImage only
```