### PR TITLE
disable WebKit DMABUF renderer to fix blank WebView

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,13 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Workaround for blank WebView windows on Linux hosts whose Mesa/GPU stack
+    // doesn't agree with the WebKit version bundled into the AppImage.
+    // Users can override by setting the variable themselves before launch.
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+
     llauncher_lib::run()
 }


### PR DESCRIPTION
Problem

The pre-built AppImage from the Releases page starts the process, but the window is blank — no UI renders. Locally built AppImages work fine on the same machine.

Root cause

Tauri's AppImage bundles the build host's libwebkit2gtk-4.1.so.0 and the entire WebKit stack. The release was built on a host whose WebKit version (or its DMABUF renderer path) doesn't agree with the Mesa/GPU stack on some target systems (commonly Arch-family distros, NVIDIA, Wayland). Result: process runs, but WebView never paints.

Fix

Set WEBKIT_DISABLE_DMABUF_RENDERER=1 in main() before Tauri initializes the WebView, on Linux only, and only if the user hasn't already set the variable. This forces WebKit onto the safer rendering path that doesn't depend on the host DMABUF stack.

- cfg(target_os = "linux") — no-op on Windows/macOS
- is_none() guard — users who explicitly set the variable (including =0) are respected
- Set before llauncher_lib::run() — guaranteed to be in place before the WebView spins up

Tradeoffs

Disabling DMABUF can mean a small perf hit on systems where it would have worked, but the alternative is "app appears broken on first launch." Users with a known-good setup can override via env var.