### PR TITLE
Add extraction & verification progress

### DIFF
--- a/src-tauri/src/api/types.rs
+++ b/src-tauri/src/api/types.rs
@@ -213,6 +213,14 @@ pub struct DownloadFileComplete {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct ExtractProgress {
+    pub percent: u8,
+    pub bytes_processed: u64,
+    pub bytes_total: u64,
+    pub speed_bps: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct DownloadComplete {
     pub version: String,
 }

--- a/src-tauri/src/download/extract.rs
+++ b/src-tauri/src/download/extract.rs
@@ -1,22 +1,154 @@
+use std::io::Read;
 use std::path::Path;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+use tauri::Emitter;
 
+use crate::api::types::ExtractProgress;
 use crate::error::AppError;
 
-pub fn extract_split_zip(first_part: &Path, extract_to: &Path) -> Result<(), AppError> {
+pub fn extract_split_zip(
+    app: &tauri::AppHandle,
+    first_part: &Path,
+    extract_to: &Path,
+    total_size: u64,
+) -> Result<(), AppError> {
     std::fs::create_dir_all(extract_to)?;
 
-    let output = std::process::Command::new("7z")
+    let total = archive_uncompressed_size(first_part)
+        .filter(|t| *t > 0)
+        .unwrap_or(total_size);
+
+    let emit = |percent: u8, processed: u64, speed: u64| {
+        app.emit(
+            "download://extract-progress",
+            ExtractProgress {
+                percent,
+                bytes_processed: processed,
+                bytes_total: total,
+                speed_bps: speed,
+            },
+        )
+        .ok();
+    };
+
+    let baseline = dir_size(extract_to);
+
+    emit(0, 0, 0);
+
+    let mut child = Command::new("7z")
         .arg("x")
         .arg("-y")
         .arg(format!("-o{}", extract_to.display()))
         .arg(first_part.to_string_lossy().to_string())
-        .output()
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|_| AppError::SevenZipNotFound)?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(AppError::ExtractionFailed(stderr.to_string()));
+    let stderr_handle = child.stderr.take().map(|mut e| {
+        thread::spawn(move || {
+            let mut s = String::new();
+            e.read_to_string(&mut s).ok();
+            s
+        })
+    });
+
+    let start = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {}
+            Err(e) => return Err(AppError::Io(e)),
+        }
+
+        let written = dir_size(extract_to).saturating_sub(baseline);
+        let processed = if total > 0 { written.min(total) } else { written };
+        let elapsed = start.elapsed().as_secs_f64();
+        let speed = if elapsed > 0.1 {
+            (processed as f64 / elapsed) as u64
+        } else {
+            0
+        };
+        let percent = if total > 0 {
+            ((processed as f64 / total as f64) * 100.0).floor().min(99.0) as u8
+        } else {
+            0
+        };
+        emit(percent, processed, speed);
+
+        thread::sleep(Duration::from_millis(400));
+    };
+
+    if !status.success() {
+        let stderr = stderr_handle
+            .and_then(|h| h.join().ok())
+            .unwrap_or_default();
+        return Err(AppError::ExtractionFailed(stderr));
     }
 
+    let final_bytes = if total > 0 {
+        total
+    } else {
+        dir_size(extract_to).saturating_sub(baseline)
+    };
+    emit(100, final_bytes, 0);
+
     Ok(())
+}
+
+fn archive_uncompressed_size(first_part: &Path) -> Option<u64> {
+    let output = Command::new("7z")
+        .arg("l")
+        .arg("-slt")
+        .arg(first_part.to_string_lossy().to_string())
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut total: u64 = 0;
+    let mut in_entries = false;
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        if !in_entries {
+            if trimmed.starts_with("----------") {
+                in_entries = true;
+            }
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("Size = ") {
+            if let Ok(n) = rest.trim().parse::<u64>() {
+                total = total.saturating_add(n);
+            }
+        }
+    }
+
+    (total > 0).then_some(total)
+}
+
+fn dir_size(path: &Path) -> u64 {
+    let mut total = 0u64;
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            match entry.file_type() {
+                Ok(ft) if ft.is_dir() => stack.push(entry.path()),
+                Ok(ft) if ft.is_file() => {
+                    if let Ok(meta) = entry.metadata() {
+                        total = total.saturating_add(meta.len());
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    total
 }

--- a/src-tauri/src/download/manager.rs
+++ b/src-tauri/src/download/manager.rs
@@ -119,11 +119,30 @@ pub async fn start_download(
         }
     }
 
-    // Extract
     let first_file_name = packs[0].url.split('/').last().unwrap_or("unknown");
     let first_part = download_path.join(first_file_name);
 
-    if let Err(e) = crate::download::extract::extract_split_zip(&first_part, game_path) {
+    let marker = crate::game::state::incomplete_marker(game_path);
+    std::fs::write(&marker, b"extracting").ok();
+
+    let extract_app = app.clone();
+    let game_path_owned = game_path.to_path_buf();
+    let extract_result = tokio::task::spawn_blocking(move || {
+        crate::download::extract::extract_split_zip(
+            &extract_app,
+            &first_part,
+            &game_path_owned,
+            total_size,
+        )
+    })
+    .await;
+
+    let extract_outcome = match extract_result {
+        Ok(inner) => inner,
+        Err(e) => Err(AppError::Api(format!("Extraction task failed: {}", e))),
+    };
+
+    if let Err(e) = extract_outcome {
         download_active.store(false, Ordering::SeqCst);
         app.emit(
             "download://error",
@@ -134,6 +153,8 @@ pub async fn start_download(
         .ok();
         return Err(e);
     }
+
+    std::fs::remove_file(&marker).ok();
 
     download_active.store(false, Ordering::SeqCst);
 

--- a/src-tauri/src/download/verify.rs
+++ b/src-tauri/src/download/verify.rs
@@ -1,12 +1,30 @@
 use md5::{Digest, Md5};
+use std::io::Read;
 use std::path::Path;
 
 use crate::error::AppError;
 
-pub fn verify_md5(path: &Path, expected: &str) -> Result<bool, AppError> {
+pub fn verify_md5_with_progress<F>(
+    path: &Path,
+    expected: &str,
+    mut on_read: F,
+) -> Result<bool, AppError>
+where
+    F: FnMut(u64) -> Result<(), AppError>,
+{
     let mut hasher = Md5::new();
     let mut file = std::fs::File::open(path)?;
-    std::io::copy(&mut file, &mut hasher)?;
+    let mut buf = vec![0u8; 1024 * 1024];
+
+    loop {
+        let n = file.read(&mut buf).map_err(AppError::Io)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+        on_read(n as u64)?;
+    }
+
     let result = format!("{:x}", hasher.finalize());
     Ok(result == expected)
 }

--- a/src-tauri/src/download/worker.rs
+++ b/src-tauri/src/download/worker.rs
@@ -30,12 +30,64 @@ pub async fn download_file(
         .unwrap_or("unknown")
         .to_string();
 
-    // Check if already downloaded with correct MD5
     if dest.exists() {
-        if crate::download::verify::verify_md5(dest, &pack.md5)? {
-            if let Ok(meta) = std::fs::metadata(dest) {
-                agg_downloaded.fetch_add(meta.len(), Ordering::Relaxed);
-            }
+        let mut last_emit = std::time::Instant::now();
+        let mut verified_local: u64 = 0;
+        let is_valid = crate::download::verify::verify_md5_with_progress(
+            dest,
+            &pack.md5,
+            |n| {
+                if !cancel_flag.load(Ordering::SeqCst) {
+                    return Err(AppError::Cancelled);
+                }
+                verified_local += n;
+                agg_downloaded.fetch_add(n, Ordering::Relaxed);
+                if last_emit.elapsed().as_millis() >= 150 {
+                    let total_dl = agg_downloaded.load(Ordering::Relaxed);
+                    let elapsed = global_start.elapsed().as_secs_f64();
+                    let speed = if elapsed > 0.1 {
+                        (total_dl as f64 / elapsed) as u64
+                    } else {
+                        0
+                    };
+                    app.emit(
+                        "download://verify-progress",
+                        DownloadProgress {
+                            file_index,
+                            total_files,
+                            file_name: file_name.clone(),
+                            bytes_downloaded: total_dl,
+                            bytes_total: agg_total,
+                            speed_bps: speed,
+                        },
+                    )
+                    .ok();
+                    last_emit = std::time::Instant::now();
+                }
+                Ok(())
+            },
+        )?;
+
+        if is_valid {
+            let total_dl = agg_downloaded.load(Ordering::Relaxed);
+            let elapsed = global_start.elapsed().as_secs_f64();
+            let speed = if elapsed > 0.1 {
+                (total_dl as f64 / elapsed) as u64
+            } else {
+                0
+            };
+            app.emit(
+                "download://verify-progress",
+                DownloadProgress {
+                    file_index,
+                    total_files,
+                    file_name: file_name.clone(),
+                    bytes_downloaded: total_dl,
+                    bytes_total: agg_total,
+                    speed_bps: speed,
+                },
+            )
+            .ok();
             app.emit(
                 "download://file-complete",
                 crate::api::types::DownloadFileComplete {
@@ -47,6 +99,8 @@ pub async fn download_file(
             .ok();
             return Ok(());
         }
+
+        agg_downloaded.fetch_sub(verified_local, Ordering::Relaxed);
     }
 
     if let Some(parent) = dest.parent() {

--- a/src-tauri/src/game/state.rs
+++ b/src-tauri/src/game/state.rs
@@ -1,7 +1,11 @@
 use serde::Serialize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::AppError;
+
+pub fn incomplete_marker(game_dir: &Path) -> PathBuf {
+    game_dir.join(".llauncher_incomplete")
+}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "status")]
@@ -29,6 +33,10 @@ pub async fn determine_game_state(
     let version_info =
         crate::api::client::get_latest_game_version(client, installed_version).await?;
     let latest_version = version_info.version;
+
+    if incomplete_marker(game_path).exists() {
+        return Ok(GameState::NotInstalled { latest_version });
+    }
 
     // Check if game is installed
     if installed_version.is_empty() || !exe_path.exists() {

--- a/src/components/home/ActionButton.css
+++ b/src/components/home/ActionButton.css
@@ -1,6 +1,9 @@
 .action-button {
   position: relative;
-  padding: 18px 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
   font-size: var(--font-size-2xl);
   font-weight: 700;
   letter-spacing: 2px;
@@ -11,7 +14,11 @@
   overflow: hidden;
   transition: all var(--transition-base);
   animation: glow 3s ease-in-out infinite;
-  min-width: 260px;
+  width: 320px;
+  height: 64px;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  white-space: nowrap;
   text-align: center;
 }
 

--- a/src/components/home/ActionButton.jsx
+++ b/src/components/home/ActionButton.jsx
@@ -1,13 +1,18 @@
 import { useTranslation } from '../../i18n';
 import './ActionButton.css';
 
-export default function ActionButton({ gameState, downloading, onAction, disabled }) {
+export default function ActionButton({ gameState, downloading, extracting, verifying, onAction, disabled }) {
   const { t } = useTranslation();
 
   if (downloading) {
+    const label = extracting
+      ? t('home.action.extracting')
+      : verifying
+        ? t('home.action.verifying')
+        : t('home.action.downloading');
     return (
       <button className="action-button action-button--downloading" disabled>
-        {t('home.action.downloading')}
+        {label}
       </button>
     );
   }

--- a/src/components/home/HomePage.css
+++ b/src/components/home/HomePage.css
@@ -60,7 +60,8 @@
   flex-direction: column;
   align-items: flex-end;
   gap: var(--space-md);
-  min-width: 300px;
+  width: 360px;
+  flex-shrink: 0;
 }
 
 .home-page__warnings {

--- a/src/components/home/HomePage.jsx
+++ b/src/components/home/HomePage.jsx
@@ -99,6 +99,8 @@ export default function HomePage({ content, settings, systemCheck, onOpenSetting
           <ActionButton
             gameState={gameState}
             downloading={downloading}
+            extracting={progress?.stage === 'extracting'}
+            verifying={progress?.stage === 'verifying'}
             onAction={handleAction}
             disabled={gameLoading}
           />

--- a/src/components/home/ProgressBar.css
+++ b/src/components/home/ProgressBar.css
@@ -29,13 +29,39 @@
   color: var(--color-text-secondary);
 }
 
+.progress-bar--extracting .progress-bar__fill {
+  background: linear-gradient(90deg, #34d399, #10b981);
+  box-shadow: 0 0 10px rgba(16, 185, 129, 0.5);
+}
+
+.progress-bar--verifying .progress-bar__fill {
+  background: linear-gradient(90deg, #fbbf24, #f59e0b);
+  box-shadow: 0 0 10px rgba(245, 158, 11, 0.5);
+}
+
+.progress-bar__stage {
+  color: var(--color-text-secondary);
+}
+
 .progress-bar__file {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);
   margin-top: var(--space-xs);
-  white-space: nowrap;
+}
+
+.progress-bar__file-name {
   overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.progress-bar__cancel {
+  flex-shrink: 0;
 }
 
 .progress-bar__cancel {

--- a/src/components/home/ProgressBar.jsx
+++ b/src/components/home/ProgressBar.jsx
@@ -6,12 +6,27 @@ export default function ProgressBar({ progress, onCancel }) {
   const { t } = useTranslation();
   if (!progress) return null;
 
-  const percent = progress.bytes_total > 0
-    ? Math.round((progress.bytes_downloaded / progress.bytes_total) * 100)
-    : 0;
+  const extracting = progress.stage === 'extracting';
+  const verifying = progress.stage === 'verifying';
+
+  const percent = extracting
+    ? progress.percent
+    : progress.bytes_total > 0
+      ? Math.round((progress.bytes_downloaded / progress.bytes_total) * 100)
+      : 0;
+
+  const done = extracting ? progress.bytes_processed : progress.bytes_downloaded;
+  const total = progress.bytes_total;
+  const eta = formatEta(total - done, progress.speed_bps);
+
+  const stageClass = extracting
+    ? 'progress-bar--extracting'
+    : verifying
+      ? 'progress-bar--verifying'
+      : '';
 
   return (
-    <div className="progress-bar">
+    <div className={`progress-bar ${stageClass}`}>
       <div className="progress-bar__track">
         <div
           className="progress-bar__fill"
@@ -20,26 +35,37 @@ export default function ProgressBar({ progress, onCancel }) {
       </div>
       <div className="progress-bar__info">
         <span>
-          {formatSize(progress.bytes_downloaded)} / {formatSize(progress.bytes_total)}
+          {formatSize(done)} / {formatSize(total)}
           {' — '}{percent}%
         </span>
         <span>
           {formatSpeed(progress.speed_bps)}
-          {(() => {
-            const eta = formatEta(progress.bytes_total - progress.bytes_downloaded, progress.speed_bps);
-            return eta ? ` — ${eta}` : '';
-          })()}
+          {eta ? ` — ${eta}` : ''}
         </span>
       </div>
       <div className="progress-bar__file">
-        {t('progress.fileLabel', {
-          current: progress.file_index + 1,
-          total: progress.total_files,
-          name: progress.file_name,
-        })}
-        <button className="progress-bar__cancel" onClick={onCancel}>
-          {t('common.cancel')}
-        </button>
+        {extracting ? (
+          <span className="progress-bar__stage">{t('progress.extractLabel')}</span>
+        ) : (
+          <>
+            <span className="progress-bar__file-name">
+              {verifying
+                ? t('progress.verifyLabel', {
+                    current: progress.file_index + 1,
+                    total: progress.total_files,
+                    name: progress.file_name,
+                  })
+                : t('progress.fileLabel', {
+                    current: progress.file_index + 1,
+                    total: progress.total_files,
+                    name: progress.file_name,
+                  })}
+            </span>
+            <button className="progress-bar__cancel" onClick={onCancel}>
+              {t('common.cancel')}
+            </button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/hooks/useDownload.js
+++ b/src/hooks/useDownload.js
@@ -11,11 +11,21 @@ export default function useDownload(onComplete) {
     const unlisteners = [];
 
     listen('download://progress', (event) => {
-      setProgress(event.payload);
+      setProgress({ stage: 'downloading', ...event.payload });
     }).then((u) => unlisteners.push(u));
 
     listen('download://file-complete', (event) => {
-      setProgress((prev) => prev ? { ...prev, ...event.payload } : event.payload);
+      setProgress((prev) =>
+        prev ? { ...prev, ...event.payload } : { stage: 'downloading', ...event.payload }
+      );
+    }).then((u) => unlisteners.push(u));
+
+    listen('download://verify-progress', (event) => {
+      setProgress({ stage: 'verifying', ...event.payload });
+    }).then((u) => unlisteners.push(u));
+
+    listen('download://extract-progress', (event) => {
+      setProgress({ stage: 'extracting', ...event.payload });
     }).then((u) => unlisteners.push(u));
 
     listen('download://complete', (event) => {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -27,6 +27,8 @@ export default {
       update: 'Update',
       launch: 'Launch',
       downloading: 'Downloading...',
+      verifying: 'Verifying...',
+      extracting: 'Extracting...',
       loading: 'Loading...',
     },
     warning: {
@@ -38,6 +40,8 @@ export default {
   },
   progress: {
     fileLabel: 'File {current}/{total}: {name}',
+    verifyLabel: 'Verifying {current}/{total}: {name}',
+    extractLabel: 'Extracting archive...',
   },
   protonPrompt: {
     title: 'DWProton Required',

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -27,6 +27,8 @@ export default {
       update: 'Обновить',
       launch: 'Запустить',
       downloading: 'Загрузка...',
+      verifying: 'Проверка...',
+      extracting: 'Распаковка...',
       loading: 'Загрузка...',
     },
     warning: {
@@ -38,6 +40,8 @@ export default {
   },
   progress: {
     fileLabel: 'Файл {current}/{total}: {name}',
+    verifyLabel: 'Проверка {current}/{total}: {name}',
+    extractLabel: 'Распаковка архива...',
   },
   protonPrompt: {
     title: 'Требуется DWProton',

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,19 +1,19 @@
 export function formatSize(bytes) {
-  if (bytes === 0) return '0 B';
+  if (!bytes || bytes <= 0) return '0 B';
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
   const i = Math.floor(Math.log(bytes) / Math.log(1024));
   return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
 }
 
 export function formatSpeed(bytesPerSecond) {
-  if (bytesPerSecond === 0) return '0 B/s';
+  if (!bytesPerSecond || bytesPerSecond <= 0) return '0 B/s';
   const units = ['B/s', 'KB/s', 'MB/s', 'GB/s'];
   const i = Math.floor(Math.log(bytesPerSecond) / Math.log(1024));
   return `${(bytesPerSecond / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
 }
 
 export function formatEta(bytesRemaining, speedBps) {
-  if (speedBps <= 0 || bytesRemaining <= 0) return '';
+  if (!(speedBps > 0) || !(bytesRemaining > 0)) return '';
   let seconds = Math.ceil(bytesRemaining / speedBps);
   const h = Math.floor(seconds / 3600);
   seconds %= 3600;


### PR DESCRIPTION
## Summary
Adds continuous progress feedback for the two previously silent download stages
- MD5 verification and archive extraction

## Changes
- **Verification progress**: cached installs previously showed `NaN` / `undefined`
  during verification; MD5 is now streamed in chunks so the bar advances smoothly.
- **Extraction progress**: extraction used to look like the download had frozen;
  it now reports real byte-accurate progress. Runs `7z` off the async runtime.
- **Corrupt-install recovery**: a `.llauncher_incomplete` marker during extraction
  forces a clean re-extract if the app is killed mid-unzip.
- **UI**: distinct downloading / verifying / extracting labels and colours; fixed
  the action button resizing/jumping when the filename length changed; hardened size/speed/ETA
  formatting.