### PR TITLE
Add: Relative Path Check and HTTP Time Out

### DIFF
--- a/src-tauri/src/api/client.rs
+++ b/src-tauri/src/api/client.rs
@@ -30,6 +30,7 @@ pub async fn get_latest_game_version(
     let resp: BatchProxyResponse = client
         .post(BATCH_PROXY_URL)
         .json(&payload)
+        .timeout(API_REQUEST_TIMEOUT)
         .send()
         .await?
         .json()
@@ -96,6 +97,7 @@ pub async fn get_launcher_content(
     let resp: BatchProxyResponse = client
         .post(WEB_BATCH_PROXY_URL)
         .json(&payload)
+        .timeout(API_REQUEST_TIMEOUT)
         .send()
         .await?
         .json()

--- a/src-tauri/src/api/constants.rs
+++ b/src-tauri/src/api/constants.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 pub const LAUNCHER_API_BASE: &str = "https://launcher.gryphline.com/api";
 pub const BATCH_PROXY_URL: &str = "https://launcher.gryphline.com/api/proxy/batch_proxy";
 pub const WEB_BATCH_PROXY_URL: &str = "https://launcher.gryphline.com/api/proxy/web/batch_proxy";
@@ -15,3 +17,14 @@ pub const GAME_APPCODE: &str = "YDUTE5gscDZ229CW";
 
 pub const CHANNEL: &str = "6";
 pub const SUB_CHANNEL: &str = "9999";
+
+/// Timeout for small metadata requests (game version check, launcher content,
+/// resource index, Proton release listings, ZIP central-directory reads).
+/// These should always return quickly; if they don't, the server or network
+/// is unreachable and we should fail fast instead of hanging the UI forever.
+pub const API_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Large file downloads have no total time limit — a multi-GB transfer can
+/// legitimately take a long time — but must not go this long without the
+/// server even starting to respond before we give up on it.
+pub const DOWNLOAD_STALL_TIMEOUT: Duration = Duration::from_secs(30);

--- a/src-tauri/src/download/manager.rs
+++ b/src-tauri/src/download/manager.rs
@@ -6,6 +6,17 @@ use tauri::Emitter;
 use crate::api::types::{DownloadComplete, DownloadError};
 use crate::error::AppError;
 
+/// Extract a safe file name from a pack URL's last path segment. Empty
+/// segments and `.`/`..` are rejected so `download_path.join(name)` can never
+/// resolve outside `download_path` — a tampered pack list could otherwise
+/// smuggle a `..` segment to escape the download directory.
+fn safe_pack_file_name(url: &str) -> &str {
+    match url.rsplit('/').next() {
+        Some(name) if !name.is_empty() && name != "." && name != ".." => name,
+        _ => "unknown",
+    }
+}
+
 pub async fn start_download(
     app: tauri::AppHandle,
     client: reqwest::Client,
@@ -53,7 +64,7 @@ pub async fn start_download(
     let existing_parts: u64 = packs
         .iter()
         .filter_map(|p| {
-            let name = p.url.split('/').last().unwrap_or("unknown");
+            let name = safe_pack_file_name(&p.url);
             std::fs::metadata(download_path.join(name)).ok().map(|m| m.len())
         })
         .sum();
@@ -99,7 +110,7 @@ pub async fn start_download(
         let app2 = app.clone();
         let client2 = client.clone();
         let pack2 = pack.clone();
-        let file_name = pack.url.split('/').last().unwrap_or("unknown").to_string();
+        let file_name = safe_pack_file_name(&pack.url).to_string();
         let dest = download_path.join(&file_name);
         let active2 = download_active.clone();
         let agg2 = agg_downloaded.clone();
@@ -158,7 +169,7 @@ pub async fn start_download(
 
     let parts: Vec<PathBuf> = packs
         .iter()
-        .map(|p| download_path.join(p.url.split('/').last().unwrap_or("unknown")))
+        .map(|p| download_path.join(safe_pack_file_name(&p.url)))
         .collect();
 
     let marker = crate::game::state::incomplete_marker(game_path);
@@ -208,4 +219,25 @@ pub async fn start_download(
     app.emit("download://complete", DownloadComplete { version: version.clone() }).ok();
 
     Ok(version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_traversal_segments_in_pack_urls() {
+        // A pack list entry whose URL ends in `/..` must not resolve
+        // `download_path.join(name)` to the parent of the download directory.
+        assert_eq!(
+            safe_pack_file_name("https://cdn.example.com/packs/.."),
+            "unknown"
+        );
+        assert_eq!(safe_pack_file_name("https://cdn.example.com/packs/."), "unknown");
+        assert_eq!(safe_pack_file_name("https://cdn.example.com/packs/"), "unknown");
+        assert_eq!(
+            safe_pack_file_name("https://cdn.example.com/packs/pack01.zip"),
+            "pack01.zip"
+        );
+    }
 }

--- a/src-tauri/src/download/packindex.rs
+++ b/src-tauri/src/download/packindex.rs
@@ -12,6 +12,7 @@
 use std::path::Path;
 use tauri::Emitter;
 
+use crate::api::constants::API_REQUEST_TIMEOUT;
 use crate::api::types::PackFile;
 use crate::error::AppError;
 
@@ -40,6 +41,7 @@ async fn range(client: &reqwest::Client, url: &str, start: u64, end_inclusive: u
     let resp = client
         .get(url)
         .header(reqwest::header::RANGE, format!("bytes={}-{}", start, end_inclusive))
+        .timeout(API_REQUEST_TIMEOUT)
         .send()
         .await?
         .error_for_status()?;

--- a/src-tauri/src/download/proton.rs
+++ b/src-tauri/src/download/proton.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::Emitter;
 
+use crate::api::constants::{API_REQUEST_TIMEOUT, DOWNLOAD_STALL_TIMEOUT};
 use crate::api::types::{ProtonDownloadComplete, ProtonDownloadProgress, ProtonReleaseInfo};
 use crate::error::AppError;
 
@@ -57,7 +58,8 @@ pub async fn get_latest_dwproton_info(
     client: &reqwest::Client,
 ) -> Result<ProtonReleaseInfo, AppError> {
     let resp: serde_json::Value = client
-        .get(&format!("{}/latest", DWPROTON_RELEASES_URL))
+        .get(format!("{}/latest", DWPROTON_RELEASES_URL))
+        .timeout(API_REQUEST_TIMEOUT)
         .send()
         .await?
         .json()
@@ -95,6 +97,7 @@ pub async fn list_dwproton_releases(
     let resp: Vec<serde_json::Value> = client
         .get(DWPROTON_RELEASES_URL)
         .query(&[("limit", "20")])
+        .timeout(API_REQUEST_TIMEOUT)
         .send()
         .await?
         .json()
@@ -126,7 +129,9 @@ pub async fn download_and_extract_dwproton(
     // Download
     emit_progress(app, 0, info.size, 0, "downloading");
 
-    let response = client.get(&info.download_url).send().await?;
+    let response =
+        crate::util::send_with_stall_timeout(client.get(&info.download_url), DOWNLOAD_STALL_TIMEOUT)
+            .await?;
     let total_size = response.content_length().unwrap_or(info.size);
 
     let mut stream = response.bytes_stream();

--- a/src-tauri/src/download/resources.rs
+++ b/src-tauri/src/download/resources.rs
@@ -123,6 +123,21 @@ fn decrypt_index(body: &[u8]) -> Result<Vec<u8>, AppError> {
     Ok(out)
 }
 
+/// Reject manifest entries whose `name` could escape `assets_root` once
+/// joined onto it (zip-slip style path traversal): absolute paths or any
+/// `..` component. The resource index is decrypted server data — a
+/// compromised/MITM'd CDN response must not be able to write outside the
+/// game's StreamingAssets directory.
+fn is_safe_relative_path(name: &str) -> bool {
+    let path = Path::new(name);
+    if path.is_absolute() {
+        return false;
+    }
+    !path
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+}
+
 fn file_md5(path: &Path) -> std::io::Result<String> {
     use std::io::Read;
     let mut file = std::fs::File::open(path)?;
@@ -154,6 +169,7 @@ async fn get_resources(
             ("platform", PLATFORM),
             ("rand_str", rand_str),
         ])
+        .timeout(API_REQUEST_TIMEOUT)
         .send()
         .await?
         .error_for_status()?
@@ -170,6 +186,7 @@ async fn fetch_index(
     let url = format!("{}/{}", res_path.trim_end_matches('/'), index_name);
     let body = client
         .get(&url)
+        .timeout(API_REQUEST_TIMEOUT)
         .send()
         .await?
         .error_for_status()?
@@ -202,6 +219,9 @@ async fn build_manifest(
         for f in files {
             let Some(md5) = f.md5 else { continue };
             if md5.is_empty() {
+                continue;
+            }
+            if !is_safe_relative_path(&f.name) {
                 continue;
             }
             out.push(ManifestFile {
@@ -433,7 +453,9 @@ async fn download_one(
         local.file_name().unwrap_or_default().to_string_lossy()
     ));
 
-    let response = client.get(&mf.url).send().await?.error_for_status()?;
+    let response = crate::util::send_with_stall_timeout(client.get(&mf.url), DOWNLOAD_STALL_TIMEOUT)
+        .await?
+        .error_for_status()?;
     let mut stream = response.bytes_stream();
     let file = tokio::fs::File::create(&tmp).await.map_err(AppError::Io)?;
     let mut writer = BufWriter::with_capacity(1024 * 1024, file);
@@ -512,6 +534,16 @@ mod tests {
     fn major_minor_takes_two_components() {
         assert_eq!(major_minor("1.3.3"), "1.3");
         assert_eq!(major_minor("1.0.14"), "1.0");
+    }
+
+    #[test]
+    fn rejects_path_traversal_in_manifest_names() {
+        // A malicious/compromised resource index must not be able to write
+        // outside the game's StreamingAssets root via `..` or an absolute path.
+        assert!(!is_safe_relative_path("../../etc/cron.d/evil"));
+        assert!(!is_safe_relative_path("VFS/../../etc/passwd"));
+        assert!(!is_safe_relative_path("/etc/passwd"));
+        assert!(is_safe_relative_path("VFS/AB/CD.chk"));
     }
 
     #[test]

--- a/src-tauri/src/download/worker.rs
+++ b/src-tauri/src/download/worker.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 use tauri::Emitter;
 use tokio::io::{AsyncWriteExt, BufWriter};
 
+use crate::api::constants::DOWNLOAD_STALL_TIMEOUT;
 use crate::api::types::{DownloadProgress, PackFile};
 use crate::error::AppError;
 
@@ -189,7 +190,9 @@ pub async fn download_file(
     if resume_from > 0 {
         request = request.header(reqwest::header::RANGE, format!("bytes={}-", resume_from));
     }
-    let response = request.send().await?.error_for_status()?;
+    let response = crate::util::send_with_stall_timeout(request, DOWNLOAD_STALL_TIMEOUT)
+        .await?
+        .error_for_status()?;
 
     let file = if resume_from > 0 && response.status() == reqwest::StatusCode::PARTIAL_CONTENT {
         tokio::fs::OpenOptions::new()

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -20,6 +20,10 @@ impl AppState {
             http_client: reqwest::Client::builder()
                 .tcp_nodelay(true)
                 .pool_max_idle_per_host(10)
+                // Bounds only the TCP/TLS handshake, so it's safe to apply to
+                // every request including large downloads — a connect that
+                // hasn't succeeded within 10s is not going to.
+                .connect_timeout(std::time::Duration::from_secs(10))
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new()),
             download_active: Arc::new(AtomicBool::new(false)),

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -1,6 +1,27 @@
 //! Small cross-cutting helpers.
 
 use std::process::Command;
+use std::time::Duration;
+
+use crate::error::AppError;
+
+/// Send a request, but don't wait forever for the server to respond: if it
+/// hasn't sent a response within `timeout`, treat the connection as dead.
+///
+/// Unlike `RequestBuilder::timeout()`, this only bounds getting the response
+/// *headers* (i.e. the `send()` future) — a large file's body can still take
+/// as long as it needs to stream once the transfer is under way. Use this for
+/// download requests; use `RequestBuilder::timeout()` directly for requests
+/// whose whole response (headers + body) is expected to be small and fast.
+pub async fn send_with_stall_timeout(
+    request: reqwest::RequestBuilder,
+    timeout: Duration,
+) -> Result<reqwest::Response, AppError> {
+    tokio::time::timeout(timeout, request.send())
+        .await
+        .map_err(|_| AppError::Api("Connection stalled: server did not respond in time".to_string()))?
+        .map_err(AppError::Http)
+}
 
 /// Strip AppImage-injected dynamic-linker paths from a child process's
 /// environment.
@@ -127,5 +148,26 @@ mod tests {
         // enough to recognise a leaked AppImage path.
         assert!(is_appimage_path("/tmp/.mount_xyz/usr/lib", None));
         assert!(!is_appimage_path("/usr/lib", None));
+    }
+
+    #[tokio::test]
+    async fn send_with_stall_timeout_gives_up_on_a_dead_connection() {
+        // A server that accepts the TCP connection but never answers (a
+        // flaky CDN edge, a stuck proxy, ...) must not hang the caller
+        // forever waiting for response headers that will never arrive.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback listener");
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            // Accept the connection and then go silent.
+            let _ = listener.accept().await;
+        });
+
+        let client = reqwest::Client::new();
+        let request = client.get(format!("http://{}/", addr));
+        let result = send_with_stall_timeout(request, Duration::from_millis(200)).await;
+
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
Add 
`.timeout(API_REQUEST_TIMEOUT)`
to check if http time out in 30s
and 
```rust
fn safe_pack_file_name(url: &str) -> &str {
    match url.rsplit('/').next() {
        Some(name) if !name.is_empty() && name != "." && name != ".." => name,
        _ => "unknown",
    }
}
```
to check if relative path is safe