### PR TITLE
Bundle GStreamer plugins in AppImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ yay -S llauncher-bin   # or: paru -S llauncher-bin
 - **Rust** toolchain ([rustup](https://rustup.rs))
 - **System libraries** for Tauri v2 — see the [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/#linux)
 - **glib-networking** — its GIO TLS module is bundled into the AppImage at build time
+- **GStreamer plugins** — the build copies the local `gstreamer-1.0` plugin directory into the AppImage for WebKitGTK
 - A **Proton** build (DWProton can be downloaded from within the launcher)
 
 ## Getting Started
@@ -71,7 +72,7 @@ npx tauri dev
 ## Building
 
 ```bash
-npx tauri build
+./build.sh
 ```
 
 Release bundles will be created in `src-tauri/target/release/bundle/`:
@@ -81,6 +82,11 @@ Release bundles will be created in `src-tauri/target/release/bundle/`:
 | AppImage | `bundle/appimage/LLauncher_0.1.0_amd64.AppImage` |
 | .deb     | `bundle/deb/LLauncher_0.1.0_amd64.deb`           |
 | .rpm     | `bundle/rpm/LLauncher-0.1.0-1.x86_64.rpm`        |
+
+AppImage builds embed the build host's GIO TLS module and GStreamer plugin
+directory via `scripts/prepare-appimage-files.sh`. To refresh those embedded
+libraries after a WebKitGTK/GStreamer update, update the distro packages on the
+build host and run `./build.sh` again.
 
 ## Configuration
 

--- a/scripts/prepare-appimage-files.sh
+++ b/scripts/prepare-appimage-files.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-# Copies the GIO TLS module (from glib-networking) into a stable path so the
-# Tauri AppImage bundler can include it (see bundle.linux.appimage.files in
-# tauri.conf.json). Without this module bundled, the AppImage shows a black
-# screen on systems where glib-networking is not installed: WebKit falls back
-# to GDummyTlsBackend and every HTTPS request fails silently (issue #11).
+# Copies runtime modules into stable paths so the Tauri AppImage bundler can
+# include them (see bundle.linux.appimage.files in tauri.conf.json).
+#
+# Without the GIO TLS module bundled, the AppImage shows a black screen on
+# systems where glib-networking is not installed: WebKit falls back to
+# GDummyTlsBackend and every HTTPS request fails silently (issue #11).
+#
+# WebKitGTK also loads GStreamer plugins dynamically. Bundling the local plugin
+# set avoids launching against a partial or incompatible host GStreamer stack on
+# SteamOS and other immutable-ish systems (issue #28).
 set -euo pipefail
 
 dest="$(cd "$(dirname "$0")/.." && pwd)/src-tauri/bundle-extra"
 mkdir -p "$dest"
 
+bundle_gio_tls_module() {
 for dir in \
     /usr/lib/x86_64-linux-gnu/gio/modules \
     /usr/lib64/gio/modules \
@@ -16,10 +22,35 @@ for dir in \
     if [ -f "$dir/libgiognutls.so" ]; then
         cp "$dir/libgiognutls.so" "$dest/libgiognutls.so"
         echo "prepare-appimage-files: bundled $dir/libgiognutls.so"
-        exit 0
+        return 0
     fi
 done
 
 echo "prepare-appimage-files: error: libgiognutls.so not found." >&2
 echo "Install glib-networking (e.g. 'apt install glib-networking' or 'pacman -S glib-networking') and retry." >&2
 exit 1
+}
+
+bundle_gstreamer_plugins() {
+    local plugin_dest="$dest/gstreamer-1.0"
+
+    for dir in \
+        /usr/lib/x86_64-linux-gnu/gstreamer-1.0 \
+        /usr/lib64/gstreamer-1.0 \
+        /usr/lib/gstreamer-1.0; do
+        if [ -d "$dir" ]; then
+            rm -rf "$plugin_dest"
+            mkdir -p "$plugin_dest"
+            cp -a "$dir"/. "$plugin_dest"/
+            echo "prepare-appimage-files: bundled GStreamer plugins from $dir"
+            return 0
+        fi
+    done
+
+    echo "prepare-appimage-files: error: GStreamer plugins directory not found." >&2
+    echo "Install GStreamer plugins (e.g. 'apt install gstreamer1.0-plugins-base gstreamer1.0-plugins-good' or 'pacman -S gst-plugins-base gst-plugins-good') and retry." >&2
+    exit 1
+}
+
+bundle_gio_tls_module
+bundle_gstreamer_plugins

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -61,6 +61,25 @@ pub fn run() {
                 }
             }
         }
+
+        // Prefer the GStreamer plugins bundled into the AppImage. WebKitGTK
+        // loads these modules dynamically, and SteamOS can otherwise mix the
+        // AppImage's WebKit stack with host plugins from a different build.
+        if std::env::var_os("GST_PLUGIN_SYSTEM_PATH_1_0").is_none() {
+            if let Some(appdir) = std::env::var_os("APPDIR") {
+                let bundled_plugins = std::path::Path::new(&appdir).join("usr/lib/gstreamer-1.0");
+                if bundled_plugins.is_dir() {
+                    let bundled_scanner = bundled_plugins.join("gst-plugin-scanner");
+
+                    std::env::set_var("GST_PLUGIN_SYSTEM_PATH_1_0", bundled_plugins);
+                    if std::env::var_os("GST_PLUGIN_SCANNER_1_0").is_none()
+                        && bundled_scanner.exists()
+                    {
+                        std::env::set_var("GST_PLUGIN_SCANNER_1_0", bundled_scanner);
+                    }
+                }
+            }
+        }
     }
 
     let settings = AppSettings::load();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,7 +32,8 @@
     "linux": {
       "appimage": {
         "files": {
-          "/usr/lib/gio/modules/libgiognutls.so": "bundle-extra/libgiognutls.so"
+          "/usr/lib/gio/modules/libgiognutls.so": "bundle-extra/libgiognutls.so",
+          "/usr/lib/gstreamer-1.0": "bundle-extra/gstreamer-1.0"
         }
       },
       "deb": {


### PR DESCRIPTION
Fixes #28.

This bundles the build host's GStreamer plugin directory into the AppImage and points GStreamer at it on launch. WebKitGTK loads these plugins dynamically, so relying on the host copy can break after rolling-release WebKit/GStreamer updates.

Also documents how to refresh the embedded libraries by rebuilding after updating the build host packages.

Tested:
- ./build.sh
- cargo test
- launched the built AppImage and confirmed it starts again